### PR TITLE
Add missing teachers in timetable.json

### DIFF
--- a/api/timetable.json
+++ b/api/timetable.json
@@ -180,7 +180,9 @@
 		"-138": "Gluszko",
 		"-139": "Czyrnecka",
 		"-140": "Marcińska",
-		"-141": "Gluszko"
+		"-141": "Gluszko",
+		"-142": "MS",
+		"-143": "Myślińska",
 	},
 	"CLASSROOM_ID": {
 		"-1": "1",

--- a/api/timetable.json
+++ b/api/timetable.json
@@ -182,7 +182,7 @@
 		"-140": "Marcińska",
 		"-141": "Gluszko",
 		"-142": "MS",
-		"-143": "Myślińska",
+		"-143": "Myślińska"
 	},
 	"CLASSROOM_ID": {
 		"-1": "1",


### PR DESCRIPTION
**Not tested locally.** Added two missing teachers. Not sure where `MS` occurs but `Myślińska` is missing - see timetable for e.g. 1A, spanish lesson group 1Hm1. Both ids taken from edupage.

~~Can there be a comma after last entry? I edited the file via github and don't think I can easily fix it without cloning the repo.~~